### PR TITLE
Add defensive checks for null `frame`

### DIFF
--- a/src/main/java/ch/bildspur/realsense/RealSenseCamera.java
+++ b/src/main/java/ch/bildspur/realsense/RealSenseCamera.java
@@ -308,7 +308,7 @@ public class RealSenseCamera implements PConstants {
 
         if (align.isEnabled()) {
             FrameList temp = align.getBlock().process(frames);
-            frames.release();
+            if (frames != null) frames.release();
             frames = temp;
         }
 
@@ -320,7 +320,7 @@ public class RealSenseCamera implements PConstants {
             if (!filters.isEmpty()) {
                 for (RSFilterBlock filter : filters) {
                     DepthFrame temp = filter.getBlock().process(frame);
-                    frame.release();
+                    if (frame != null) frame.release();
                     frame = temp;
                 }
             }
@@ -332,31 +332,31 @@ public class RealSenseCamera implements PConstants {
                 coloredFrame.release();
             }
 
-            frame.release();
+            if (frame != null) frame.release();
         }
 
         if (colorStream.isEnabled()) {
             VideoFrame frame = frames.getColorFrame();
             colorStream.copyPixels(frame);
-            frame.release();
+            if (frame != null) frame.release();
         }
 
         if (firstIRStream.isEnabled()) {
             VideoFrame frame = getStreamByIndex(frames, Stream.Infrared, Format.Any, firstIRStream.getIndex());
             firstIRStream.copyPixels(frame);
-            frame.release();
+            if (frame != null) frame.release();
         }
 
         if (secondIRStream.isEnabled()) {
             VideoFrame frame = getStreamByIndex(frames, Stream.Infrared, Format.Any, secondIRStream.getIndex());
             secondIRStream.copyPixels(frame);
-            frame.release();
+            if (frame != null) frame.release();
         }
 
         if (poseStream.isEnabled()) {
             PoseFrame frame = frames.getPoseFrame();
 
-            frame.release();
+            if (frame != null) frame.release();
         }
     }
 
@@ -368,7 +368,7 @@ public class RealSenseCamera implements PConstants {
                     && frame.getProfile().getIndex() == index) {
                 return (T) frame;
             }
-            frame.release();
+            if (frame != null) frame.release();
         }
         return null;
     }
@@ -620,9 +620,13 @@ public class RealSenseCamera implements PConstants {
     public short[][] getDepthData() {
         checkRunning();
 
-        DepthFrame frame = frames.getDepthFrame();
-        depthStream.updateDepthData(frame);
-        frame.release();
+        if (frames != null) {
+            DepthFrame frame = frames.getDepthFrame();
+            if (frame != null) {
+                depthStream.updateDepthData(frame);
+                frame.release();
+            }
+        }
         return depthStream.getData();
     }
 

--- a/src/main/java/ch/bildspur/realsense/RealSenseCamera.java
+++ b/src/main/java/ch/bildspur/realsense/RealSenseCamera.java
@@ -315,48 +315,59 @@ public class RealSenseCamera implements PConstants {
         // copy streams
         if (depthStream.isEnabled()) {
             DepthFrame frame = frames.getDepthFrame();
-
-            // apply depth filter
-            if (!filters.isEmpty()) {
-                for (RSFilterBlock filter : filters) {
-                    DepthFrame temp = filter.getBlock().process(frame);
-                    if (frame != null) frame.release();
-                    frame = temp;
+            if (frame != null) {
+            
+                // apply depth filter
+                if (!filters.isEmpty()) {
+                    for (RSFilterBlock filter : filters) {
+                        DepthFrame temp = filter.getBlock().process(frame);
+                        frame.release();
+                        frame = temp;
+                    }
                 }
-            }
 
-            // update colors if colorized is there
-            if (colorizer.isEnabled()) {
-                VideoFrame coloredFrame = colorizer.getBlock().colorize(frame);
-                depthStream.copyPixels(coloredFrame);
-                coloredFrame.release();
-            }
+                // update colors if colorized is there
+                if (colorizer.isEnabled()) {
+                    VideoFrame coloredFrame = colorizer.getBlock().colorize(frame);
+                    if(coloredFrame != null) {
+                        depthStream.copyPixels(coloredFrame);
+                        coloredFrame.release();
+                    }
+                }
 
-            if (frame != null) frame.release();
+                frame.release();
+            }
         }
 
         if (colorStream.isEnabled()) {
             VideoFrame frame = frames.getColorFrame();
-            colorStream.copyPixels(frame);
-            if (frame != null) frame.release();
+            if (frame != null) {
+                colorStream.copyPixels(frame);
+                frame.release();
+            }
         }
 
         if (firstIRStream.isEnabled()) {
             VideoFrame frame = getStreamByIndex(frames, Stream.Infrared, Format.Any, firstIRStream.getIndex());
-            firstIRStream.copyPixels(frame);
-            if (frame != null) frame.release();
+            if (frame != null) {
+                firstIRStream.copyPixels(frame);
+                frame.release();
+            }
         }
 
         if (secondIRStream.isEnabled()) {
             VideoFrame frame = getStreamByIndex(frames, Stream.Infrared, Format.Any, secondIRStream.getIndex());
-            secondIRStream.copyPixels(frame);
-            if (frame != null) frame.release();
+            if (frame != null) {
+                secondIRStream.copyPixels(frame);
+                frame.release();
+            }
         }
 
         if (poseStream.isEnabled()) {
             PoseFrame frame = frames.getPoseFrame();
-
-            if (frame != null) frame.release();
+            if (frame != null) {
+                frame.release();
+            }
         }
     }
 
@@ -368,7 +379,9 @@ public class RealSenseCamera implements PConstants {
                     && frame.getProfile().getIndex() == index) {
                 return (T) frame;
             }
-            if (frame != null) frame.release();
+            if (frame != null) {
+                frame.release();
+            }
         }
         return null;
     }


### PR DESCRIPTION
Noted in [this issue](https://github.com/cansik/realsense-processing/issues/41), I was experiencing many null pointer exceptions while running the Realsense library in a thread. I've added null checks before using the `frame` objects, which were causing exceptions if they were null. This has solved the errors I was seeing, and hopefully doesn't have any negative impacts